### PR TITLE
adding favoriting functionality to boards

### DIFF
--- a/app/(dashboard)/_component/board-card/footer.tsx
+++ b/app/(dashboard)/_component/board-card/footer.tsx
@@ -1,5 +1,6 @@
 import { Star } from "lucide-react";
 import { cn } from "@/lib/utils";
+import React from "react";
 
 interface FooterProps {
   isFavorite: boolean;
@@ -18,6 +19,14 @@ export const Footer = ({
   onClick,
   disabled,
 }: FooterProps) => {
+  const handelClick = (
+    event: React.MouseEvent<HTMLButtonElement, MouseEvent>
+  ) => {
+    event.stopPropagation();
+    event.preventDefault();
+
+    onClick();
+  };
   return (
     <div className="relative bg-white p-3">
       <p className="text-[13px] truncate max-w-[calc(100%-20px)]">{title}</p>
@@ -27,7 +36,7 @@ export const Footer = ({
 
       <button
         disabled={disabled}
-        onClick={onClick}
+        onClick={handelClick}
         className={cn(
           "opacity-0 group-hover:opacity-100 transition absolute top-3 right-3 text-muted-foreground hover:text-yellow-600",
           disabled && "cursor-not-allowed opacity-75"

--- a/app/(dashboard)/_component/board-card/index.tsx
+++ b/app/(dashboard)/_component/board-card/index.tsx
@@ -9,6 +9,10 @@ import { Footer } from "./footer";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Actions } from "@/components/action";
 import { MoreHorizontal } from "lucide-react";
+import { api } from "@/convex/_generated/api";
+import { useApiMutation } from "@/hooks/use-api-mutation";
+import { toast } from "sonner";
+import { useMutation } from "convex/react";
 interface BoardCardProps {
   id: string;
   title: string;
@@ -34,6 +38,30 @@ export const BoardCard = ({
   const createdAtLabel = formatDistanceToNow(createdAt, {
     addSuffix: true,
   });
+
+  // Alternative implementation
+  // const handelFavorite = useMutation(api.board.favorite);
+  // const handelUnFavorite = useMutation(api.board.unfavorite);
+
+  const { mutate: onFavorite, pending: pendingFavorite } = useApiMutation(
+    api.board.favorite
+  );
+
+  const { mutate: onUnFavorite, pending: pendingUnFavorite } = useApiMutation(
+    api.board.unfavorite
+  );
+
+  const toggleFavorite = () => {
+    if (isFavorite) {
+      onUnFavorite({ id }).catch(() =>
+        toast.error("Failed to unfavorite board")
+      );
+    } else {
+      onFavorite({ id, orgId }).catch(() =>
+        toast.error("Failed to favorite board")
+      );
+    }
+  };
   return (
     <Link href={`/board/${id}`}>
       <div className="group aspect-[100/127] border rounded-lg flex flex-col justify-between overflow-hidden ">
@@ -51,8 +79,8 @@ export const BoardCard = ({
           title={title}
           authorlabe={authorlabe}
           createdAtLabel={createdAtLabel}
-          onClick={() => {}}
-          disabled={false}
+          onClick={toggleFavorite}
+          disabled={pendingFavorite || pendingUnFavorite}
         />
       </div>
     </Link>

--- a/app/(dashboard)/_component/board-list.tsx
+++ b/app/(dashboard)/_component/board-list.tsx
@@ -69,7 +69,7 @@ export const BoardList = ({ orgId, query }: BoardListProps) => {
             authorname={board.authorName}
             createdAt={board._creationTime}
             orgId={board.orgId}
-            isFavorite={false}
+            isFavorite={board.isFavorite}
           />
         ))}
       </div>

--- a/convex/board.ts
+++ b/convex/board.ts
@@ -83,3 +83,73 @@ export const update = mutation({
     return board;
   },
 });
+
+export const favorite = mutation({
+  args: { id: v.id("boards"), orgId: v.string() },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthorized");
+    }
+
+    const board = await ctx.db.get(args.id);
+
+    if (!board) {
+      throw new Error("Board not found");
+    }
+
+    const userId = identity.subject;
+    const existingFavorite = await ctx.db
+      .query("userFavorites")
+      .withIndex("by_user_board_org", (q) =>
+        q.eq("userId", userId).eq("boardId", args.id).eq("orgId", args.orgId)
+      )
+      .unique();
+
+    if (existingFavorite) {
+      throw new Error("Board already favorited");
+    }
+
+    await ctx.db.insert("userFavorites", {
+      userId,
+      boardId: args.id,
+      orgId: args.orgId,
+    });
+
+    return board;
+  },
+});
+
+export const unfavorite = mutation({
+  args: { id: v.id("boards") },
+  handler: async (ctx, args) => {
+    const identity = await ctx.auth.getUserIdentity();
+    if (!identity) {
+      throw new Error("Unauthorized");
+    }
+
+    const board = await ctx.db.get(args.id);
+
+    if (!board) {
+      throw new Error("Board not found");
+    }
+
+    const userId = identity.subject;
+    const existingFavorite = await ctx.db
+      .query("userFavorites")
+      .withIndex(
+        "by_user_board",
+        (q) => q.eq("userId", userId).eq("boardId", args.id)
+        //TODO : Check if orgId is needed
+      )
+      .unique();
+
+    if (!existingFavorite) {
+      throw new Error("Favorite board not found");
+    }
+
+    await ctx.db.delete(existingFavorite._id);
+
+    return board;
+  },
+});

--- a/convex/boards.ts
+++ b/convex/boards.ts
@@ -18,6 +18,24 @@ export const get = query({
       .order("desc")
       .collect();
 
-    return boards;
+    const boardsWithFavoritesRelation = boards.map((board) => {
+      return ctx.db
+        .query("userFavorites")
+        .withIndex("by_user_board", (q) =>
+          q.eq("userId", identity.subject).eq("boardId", board._id)
+        )
+        .unique()
+        .then((favorite) => {
+          return {
+            ...board,
+            isFavorite: !!favorite,
+          };
+        });
+    });
+
+    const boardsWithFavoritesBoolean = await Promise.all(
+      boardsWithFavoritesRelation
+    );
+    return boardsWithFavoritesBoolean;
   },
 });

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -14,4 +14,14 @@ export default defineSchema({
       searchField: "title",
       filterFields: ["orgId"],
     }),
+
+  userFavorites: defineTable({
+    orgId: v.string(),
+    userId: v.string(),
+    boardId: v.string(),
+  })
+    .index("by_board", ["boardId"])
+    .index("by_user_org", ["userId", "orgId"])
+    .index("by_user_board", ["userId", "boardId"])
+    .index("by_user_board_org", ["userId", "boardId", "orgId"]),
 });


### PR DESCRIPTION
Canva: add favoriting functionality to boards

- Added star icon to board items for favoriting/unfavoriting.
- Updated UI to highlight favorited boards using Tailwind CSS.
- Implemented state management to track favorite status.
- Added backend support to persist favorite status.

